### PR TITLE
fix compile on linux and macos

### DIFF
--- a/Libconfig.xs
+++ b/Libconfig.xs
@@ -408,6 +408,7 @@ int sv2addarray(config_setting_t *parent_setting, char *key, config_setting_t *s
 						break;
 					}
 				default:
+					break;
 			}
 		}
 		else
@@ -433,6 +434,7 @@ int sv2addarray(config_setting_t *parent_setting, char *key, config_setting_t *s
 						break;
 					}
 				default:
+					break;
 			}
 		}
 	}
@@ -475,6 +477,7 @@ int sv2addobject(config_setting_t *parent_setting, char *key, config_setting_t *
 						break;
 					}
 				default:
+					break;
 			}
 		}
 		else
@@ -497,6 +500,7 @@ int sv2addobject(config_setting_t *parent_setting, char *key, config_setting_t *
 						break;
 					}
 				default:
+					break;
 			}
 		}
 	}
@@ -530,6 +534,7 @@ int set_general_value(Conf__Libconfig conf, const char *path, SV *sv)
 					break;
 				}
 			default:
+				break;
 		}
 	}
 	else
@@ -552,6 +557,7 @@ int set_general_value(Conf__Libconfig conf, const char *path, SV *sv)
 					break;
 				}
 			default:
+				break;
 		}
 	}
 	return ret;
@@ -659,9 +665,11 @@ get_general_value(Conf__Libconfig conf, const char *path, SV **svref)
 			*svref = newSVnv(config_setting_get_float(elem));
 			break;
 		case CONFIG_TYPE_STRING:
-			const char *val = config_setting_get_string(elem);
-			*svref = newSVpvn(val, strlen(val));
-			break;
+			{
+				const char *val = config_setting_get_string(elem);
+				*svref = newSVpvn(val, strlen(val));
+				break;
+			}
 		case CONFIG_TYPE_ARRAY:
 			{
 				return get_general_array(elem, svref);

--- a/README
+++ b/README
@@ -19,8 +19,8 @@ On other platforms, you can compile libconfig from source:
 Instructions:
 
     wget http://www.hyperrealm.com/libconfig/libconfig-1.3.2.tar.gz
-	# Support libconfig-1.4.x
-	# wget http://www.hyperrealm.com/libconfig/libconfig-1.4.7.tar.gz
+    # Support libconfig-1.4.x
+    # wget http://www.hyperrealm.com/libconfig/libconfig-1.4.7.tar.gz
     # Support libconfig-1.7.x 
     # wget https://hyperrealm.github.io/libconfig/dist/libconfig-1.7.2.tar.gz 
     tar -zxf libconfig-1.3.2.tar.gz
@@ -38,7 +38,7 @@ To install this module, run the following commands:
     # or if you use a self-compiled libconfig as above:
     # perl Makefile.PL LIBS=-L$MYPREFIX/lib INC=-I$MYPREFIX/include
     make
-	# If not using en_US system, you must set export LC_ALL=en_US.UTF-8 
+    # If not using en_US system, you must set export LC_ALL=en_US.UTF-8 
     make test
     make install
 


### PR DESCRIPTION
There were compile errors on macOS (10.14) and Linux (Debian 11). This fixes them. It seems that some compilers insist on a switch "default:" being followed by a statement (so I added "break;"), and they didn't like a variable declaration in a switch case (so I added curly braces to make it a compound statement).

Also, there were also three stray tabs in the README which made it look inconsistent, so I changed them to spaces.

This should fix issue #4. Oh, no it doesn't. It only fixes the initial list of compile errors, not the the missing `av_count()` function. The module's tests fail. Isn't `av_count` part of the perl api for xs?

According to https://perldoc.perl.org/perlapi `av_count` should exist. I don't know where it's gone, but it also says that it's always the same as `av_top_index(av) + 1`, so I've added an `av_count` macro and most of the tests pass now, but `t/04-specread.t` fails with segfault, as mentioned by @yrutschle.

I think the real question is what happened to `av_count()`? Where is it?

I'll remove the `av_count` macro. It just masks the problem.

I've created an issue with perl to see if they have any ideas https://github.com/Perl/perl5/issues/21175 (av_count() is an undefined symbol (Debian 11)) but I wouldn't be surprised if it's a debian perl package bug. Or maybe a bug in this module, but I don't know anything about XS.

By the way (possibly unrelated), when compiling on macOS 10.14, and linking against a libconfig installed by macports, there's a different link error when running tests:

    Symbol not found: _config_destroy
