### PR TITLE
add .github/workflows/test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+---
+name: test
+
+on:
+  push:
+    branches:
+      - "*"
+    tags-ignore:
+      - "*"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  perls:
+    name: "Linux with Perl ${{ matrix.perl-version }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version:
+          - "devel"
+          - "5.38"
+          - "5.36"
+          - "5.34"
+          - "5.32"
+          - "5.30"
+          - "5.28"
+          - "5.26"
+          - "5.24"
+          - "5.22"
+          - "5.20"
+          - "5.18"
+          - "5.16"
+          - "5.14"
+          - "5.12"
+          - "5.10"
+          - "5.8"
+    container:
+      image: perldocker/perl-tester:${{ matrix.perl-version }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run tests
+        run: |
+          perl --version
+          apt-get -y install libconfig-dev
+          perl Makefile.PL
+          make
+          make test
+          make install
+# vi:set et ts=2 sw=2:


### PR DESCRIPTION
Hi, This pull request adds github actions for testing on all perl versions from 5.8 to 5.38.

Strangely, the tests only work fully on perl 5.34.

On more recent perl versions (5.36-5.38), the 04-specread test crashes (like we were seeing on debian-11 with perl-5.32).

On perl 5.32 and below, there is a cpp error relating to `PERL_VERSION_GT` (unlike what we saw earlier).

In perl 5.8-5.16, in addition to the cpp error, there is a warning about `av_top_index` not being declared (only the suggested alternative changed between these versions - the warning is otherwise the same). Presumably, when the cpp is error is fixed, the next problem would be a linker error.

Note: When checking test failures, I always need to view the raw logs. The web interface only ever says "Error:"

Here are the details from the raw logs:

Perl 5.38, 5.36

    t/04-specread.t .... 
    Failed 9/10 subtests 
    Test Summary Report
    -------------------
    t/04-specread.t  (Wstat: 139 (Signal: SEGV, dumped core) Tests: 1 Failed: 0)
      Non-zero wait status: 139
      Parse errors: Bad plan.  You planned 10 tests but ran 1.
    Failed 1/18 test programs. 0/24026 subtests failed.
    t/05-add.t       (Wstat: 0 Tests: 42 Failed: 0)
      TODO passed:   40
    Files=18, Tests=24026,  6 wallclock secs ( 1.49 usr  0.15 sys +  4.51 cusr  0.67 csys =  6.82 CPU)
    Result: FAIL

Perl 5.34

    t/04-specread.t .... ok
    All tests successful
    Result: PASS

Perl 5.32, 5.30, 5.28, 5.26, 5.24, 5.22, 5.20, 5.18

    Libconfig.xs: In function 'sv2addarray':
    Libconfig.xs:365:20: error: missing binary operator before token "("
     #if PERL_VERSION_GT(5,32,0)
                        ^

Perl 5.16

    Libconfig.xs: In function 'sv2addarray':
    Libconfig.xs:365:20: error: missing binary operator before token "("
     #if PERL_VERSION_GT(5,32,0)
                        ^
    Libconfig.xs:368:14: warning: implicit declaration of function 'av_top_index'; did you mean 'sv_tainted'? [-Wimplicit-function-declaration]
      int avlen = av_top_index(av) + 1;
                  ^~~~~~~~~~~~
                  sv_tainted

Perl 5.14

    Libconfig.xs: In function 'sv2addarray':
    Libconfig.xs:365:20: error: missing binary operator before token "("
     #if PERL_VERSION_GT(5,32,0)
                        ^
    Libconfig.xs:368:14: warning: implicit declaration of function 'av_top_index'; did you mean 'PL_Gop_mutex'? [-Wimplicit-function-declaration]
      int avlen = av_top_index(av) + 1;
                  ^~~~~~~~~~~~
                  PL_Gop_mutex

Perl 5.12, 5.10, 5.8

    Libconfig.xs: In function 'sv2addarray':
    Libconfig.xs:365:20: error: missing binary operator before token "("
     #if PERL_VERSION_GT(5,32,0)
                        ^
    Libconfig.xs:368:14: warning: implicit declaration of function 'av_top_index'; did you mean 'pp_index'? [-Wimplicit-function-declaration]
      int avlen = av_top_index(av) + 1;
                  ^~~~~~~~~~~~
                  pp_index
